### PR TITLE
fix: import fs/v2 instead of v1

### DIFF
--- a/chroot_test.go
+++ b/chroot_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/codeclysm/fs"
+	"github.com/codeclysm/fs/v2"
 )
 
 func TestChroot(t *testing.T) {

--- a/fsutil/fsutil.go
+++ b/fsutil/fsutil.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/codeclysm/fs"
+	"github.com/codeclysm/fs/v2"
 )
 
 type Util interface {

--- a/fsutil/fsutil_test.go
+++ b/fsutil/fsutil_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/codeclysm/fs"
-	"github.com/codeclysm/fs/fsutil"
+	"github.com/codeclysm/fs/v2"
+	"github.com/codeclysm/fs/v2/fsutil"
 )
 
 func TestChrootWalk(t *testing.T) {

--- a/fsutil/lock.go
+++ b/fsutil/lock.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/codeclysm/fs"
+	"github.com/codeclysm/fs/v2"
 	"github.com/gofrs/flock"
 )
 

--- a/fsutil/lock_test.go
+++ b/fsutil/lock_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/codeclysm/fs"
-	"github.com/codeclysm/fs/fsutil"
+	"github.com/codeclysm/fs/v2"
+	"github.com/codeclysm/fs/v2/fsutil"
 )
 
 func TestLock(t *testing.T) {

--- a/spread_test.go
+++ b/spread_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/codeclysm/fs"
+	"github.com/codeclysm/fs/v2"
 )
 
 func TestSpreadChroot(t *testing.T) {


### PR DESCRIPTION
The library used the v1 version instead of the v2 one for local imports. Fixes the imports in all the files.